### PR TITLE
Fix WP_Query argument name in index page

### DIFF
--- a/index.php
+++ b/index.php
@@ -118,7 +118,7 @@ get_header();
                         'posts_per_page' => 10,
                         'post_status' => 'publish',
                         'post__not_in' => $displayed_posts,
-                        'post-type' => 'post'
+                        'post_type' => 'post'
                     );
                     $query3 = new WP_Query($args3);
 


### PR DESCRIPTION
## Summary
- fix property name for posts list query in index.php

## Testing
- `php -l index.php`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68875866849c83289d969a6b4adbfc83